### PR TITLE
Add strong to the masculine word list

### DIFF
--- a/app/wordlists.py
+++ b/app/wordlists.py
@@ -104,6 +104,7 @@ masculine_coded_words = [
     "selfconfiden",
     "selfrelian",
     "selfsufficien",
+    "strong",
     "stubborn",
     "superior",
     "unreasonab"


### PR DESCRIPTION
In [the study](http://gender-decoder.katmatfield.com/static/documents/Gaucher-Friesen-Kay-JPSP-Gendered-Wording-in-Job-ads.pdf), the following is a snip from one of the masculine job postings used for research. See Appendix B
Job Advertisements Used in Studies 3–5

> Strong communication and influencing skills

I recommend adding "strong" to the list of masculine words.